### PR TITLE
Pu various warnings

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/AbstractWebTestCase.php
@@ -33,7 +33,7 @@ abstract class AbstractWebTestCase extends BaseWebTestCase
         static::deleteTmpDir();
     }
 
-    public function provideSecuritySystems()
+    public static function provideSecuritySystems()
     {
         yield [['enable_authenticator_manager' => true]];
         yield [['enable_authenticator_manager' => false]];

--- a/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Config/ContainerParametersResourceCheckerTest.php
@@ -46,7 +46,7 @@ class ContainerParametersResourceCheckerTest extends TestCase
      */
     public function testIsFresh(callable $mockContainer, $expected)
     {
-        $mockContainer($this->container);
+        $mockContainer($this->container, $this);
 
         $this->assertSame($expected, $this->resourceChecker->isFresh($this->resource, time()));
     }
@@ -61,9 +61,9 @@ class ContainerParametersResourceCheckerTest extends TestCase
             $container->method('getParameter')->with('locales')->willReturn(['nl', 'es']);
         }, false];
 
-        yield 'fresh on every identical parameters' => [function (MockObject $container) {
-            $container->expects(self::exactly(2))->method('hasParameter')->willReturn(true);
-            $container->expects(self::exactly(2))->method('getParameter')
+        yield 'fresh on every identical parameters' => [function (MockObject $container, TestCase $testCase) {
+            $container->expects($testCase->exactly(2))->method('hasParameter')->willReturn(true);
+            $container->expects($testCase->exactly(2))->method('getParameter')
                 ->willReturnCallback(function (...$args) {
                     static $series = [
                         [['locales'], ['fr', 'en']],

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/PhpFileLoaderTest.php
@@ -194,6 +194,8 @@ class PhpFileLoaderTest extends TestCase
      */
     public function testWhenEnv()
     {
+        $this->expectNotToPerformAssertions();
+
         $fixtures = realpath(__DIR__.'/../Fixtures');
         $container = new ContainerBuilder();
         $loader = new PhpFileLoader($container, new FileLocator(), 'dev', new ConfigBuilderGenerator(sys_get_temp_dir()));

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/CompiledUrlGeneratorDumperTest.php
@@ -63,10 +63,12 @@ class CompiledUrlGeneratorDumperTest extends TestCase
         parent::tearDown();
 
         @unlink($this->testTmpFilepath);
+        @unlink($this->largeTestTmpFilepath);
 
         $this->routeCollection = null;
         $this->generatorDumper = null;
         $this->testTmpFilepath = null;
+        $this->largeTestTmpFilepath = null;
     }
 
     public function testDumpWithRoutes()

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CallbacksTestTrait.php
@@ -126,13 +126,13 @@ trait CallbacksTestTrait
         $normalizer->normalize($obj, null, ['callbacks' => $callbacks]);
     }
 
-    public function provideNormalizeCallbacks()
+    public static function provideNormalizeCallbacks()
     {
         return [
             'Change a string' => [
                 [
                     'bar' => function ($bar) {
-                        $this->assertEquals('baz', $bar);
+                        static::assertEquals('baz', $bar);
 
                         return 'baz';
                     },
@@ -143,11 +143,11 @@ trait CallbacksTestTrait
             'Null an item' => [
                 [
                     'bar' => function ($value, $object, $attributeName, $format, $context) {
-                        $this->assertSame('baz', $value);
-                        $this->assertInstanceOf(CallbacksObject::class, $object);
-                        $this->assertSame('bar', $attributeName);
-                        $this->assertSame('any', $format);
-                        $this->assertArrayHasKey('circular_reference_limit_counters', $context);
+                        static::assertSame('baz', $value);
+                        static::assertInstanceOf(CallbacksObject::class, $object);
+                        static::assertSame('bar', $attributeName);
+                        static::assertSame('any', $format);
+                        static::assertArrayHasKey('circular_reference_limit_counters', $context);
                     },
                 ],
                 'baz',
@@ -156,7 +156,7 @@ trait CallbacksTestTrait
             'Format a date' => [
                 [
                     'bar' => function ($bar) {
-                        $this->assertInstanceOf(\DateTime::class, $bar);
+                        static::assertInstanceOf(\DateTime::class, $bar);
 
                         return $bar->format('d-m-Y H:i:s');
                     },
@@ -190,13 +190,13 @@ trait CallbacksTestTrait
         ];
     }
 
-    public function provideDenormalizeCallbacks(): array
+    public static function provideDenormalizeCallbacks(): array
     {
         return [
             'Change a string' => [
                 [
                     'bar' => function ($bar) {
-                        $this->assertEquals('bar', $bar);
+                        static::assertEquals('bar', $bar);
 
                         return $bar;
                     },
@@ -207,11 +207,11 @@ trait CallbacksTestTrait
             'Null an item' => [
                 [
                     'bar' => function ($value, $object, $attributeName, $format, $context) {
-                        $this->assertSame('baz', $value);
-                        $this->assertTrue(is_a($object, CallbacksObject::class, true));
-                        $this->assertSame('bar', $attributeName);
-                        $this->assertSame('any', $format);
-                        $this->assertIsArray($context);
+                        static::assertSame('baz', $value);
+                        static::assertTrue(is_a($object, CallbacksObject::class, true));
+                        static::assertSame('bar', $attributeName);
+                        static::assertSame('any', $format);
+                        static::assertIsArray($context);
                     },
                 ],
                 'baz',
@@ -220,7 +220,7 @@ trait CallbacksTestTrait
             'Format a date' => [
                 [
                     'bar' => function ($bar) {
-                        $this->assertIsString($bar);
+                        static::assertIsString($bar);
 
                         return \DateTime::createFromFormat('d-m-Y H:i:s', $bar);
                     },
@@ -254,13 +254,13 @@ trait CallbacksTestTrait
         ];
     }
 
-    public function providerDenormalizeCallbacksWithTypedProperty(): array
+    public static function providerDenormalizeCallbacksWithTypedProperty(): array
     {
         return [
             'Change a typed string' => [
                 [
                     'foo' => function ($foo) {
-                        $this->assertEquals('foo', $foo);
+                        static::assertEquals('foo', $foo);
 
                         return $foo;
                     },
@@ -271,11 +271,11 @@ trait CallbacksTestTrait
             'Null an typed item' => [
                 [
                     'foo' => function ($value, $object, $attributeName, $format, $context) {
-                        $this->assertSame('fool', $value);
-                        $this->assertTrue(is_a($object, CallbacksObject::class, true));
-                        $this->assertSame('foo', $attributeName);
-                        $this->assertSame('any', $format);
-                        $this->assertIsArray($context);
+                        static::assertSame('fool', $value);
+                        static::assertTrue(is_a($object, CallbacksObject::class, true));
+                        static::assertSame('foo', $attributeName);
+                        static::assertSame('any', $format);
+                        static::assertIsArray($context);
                     },
                 ],
                 'fool',
@@ -284,7 +284,7 @@ trait CallbacksTestTrait
         ];
     }
 
-    public function provideInvalidCallbacks()
+    public static function provideInvalidCallbacks()
     {
         return [
             [['bar' => null]],

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CircularReferenceTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/CircularReferenceTestTrait.php
@@ -23,7 +23,7 @@ trait CircularReferenceTestTrait
 
     abstract protected function getSelfReferencingModel();
 
-    public function provideUnableToNormalizeCircularReference(): array
+    public static function provideUnableToNormalizeCircularReference(): array
     {
         return [
             [[], [], 1],

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/Features/SkipUninitializedValuesTestTrait.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/Features/SkipUninitializedValuesTestTrait.php
@@ -44,7 +44,7 @@ trait SkipUninitializedValuesTestTrait
         $this->assertSame('value', $objectToPopulate->getUninitialized());
     }
 
-    public function skipUninitializedValuesFlagProvider(): iterable
+    public static function skipUninitializedValuesFlagProvider(): iterable
     {
         yield 'passed manually' => [['skip_uninitialized_values' => true, 'groups' => ['foo']]];
         yield 'using default context value' => [['groups' => ['foo']]];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 5.4
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Issues        | -
| License       | MIT

We found out with xabbuh that some warnings are "hidden" in the test suite of 5.4. Indeed, a risky test was raised in upper branches (from 6.4). However, this test wasn't raised as risky in the 5.4 branch. This happens when using the `phpunit` script, but **not** when executing a "classic" PHPUnit install.

I went through components and bundle and executed PHPUnit to fix various warnings and deprecations hidden in the 5.4 CI. We don't know yet why 5.4 behaves this way.