### PR TITLE
[VarDumper] Add an options builder to configure VarDumper's behaviour…

### DIFF
--- a/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
+++ b/src/Symfony/Bundle/DebugBundle/Resources/config/services.php
@@ -22,6 +22,7 @@ use Symfony\Component\VarDumper\Command\Descriptor\CliDescriptor;
 use Symfony\Component\VarDumper\Command\Descriptor\HtmlDescriptor;
 use Symfony\Component\VarDumper\Command\ServerDumpCommand;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\BacktraceContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\CliContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\RequestContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
@@ -87,6 +88,10 @@ return static function (ContainerConfigurator $container) {
                         param('kernel.project_dir'),
                         service('debug.file_link_formatter')->nullOnInvalid(),
                     ]),
+                    'backtrace' => inline_service(BacktraceContextProvider::class)->args([
+                        0,
+                        service('var_dump.cloner')->nullOnInvalid(),
+                    ]),
                 ],
             ])
 
@@ -111,6 +116,10 @@ return static function (ContainerConfigurator $container) {
                     ]),
                     'request' => inline_service(RequestContextProvider::class)->args([service('request_stack')]),
                     'cli' => inline_service(CliContextProvider::class),
+                    'backtrace' => inline_service(BacktraceContextProvider::class)->args([
+                        0,
+                        service('var_dump.cloner')->nullOnInvalid(),
+                    ]),
                 ],
             ])
 

--- a/src/Symfony/Component/VarDumper/CHANGELOG.md
+++ b/src/Symfony/Component/VarDumper/CHANGELOG.md
@@ -30,6 +30,7 @@ CHANGELOG
  * Add support of named arguments to `dd()` and `dump()` to display the argument name
  * Add support for `Relay\Relay`
  * Add display of invisible characters
+ * Add support of options when using `dd()` and `dump()`
 
 6.2
 ---

--- a/src/Symfony/Component/VarDumper/Cloner/Data.php
+++ b/src/Symfony/Component/VarDumper/Cloner/Data.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\VarDumper\Cloner;
 
 use Symfony\Component\VarDumper\Caster\Caster;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\BacktraceContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 
 /**
@@ -270,12 +271,17 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
         $cursor->hashType = -1;
         $cursor->attr = $this->context[SourceContextProvider::class] ?? [];
         $label = $this->context['label'] ?? '';
+        $options = $this->context['options'] ?? [];
 
         if ($cursor->attr || '' !== $label) {
             $dumper->dumpScalar($cursor, 'label', $label);
         }
         $cursor->hashType = 0;
         $this->dumpItem($dumper, $cursor, $refs, $this->data[$this->position][$this->key]);
+
+        if (false !== ($options['_trace'] ?? false) && $cursor->attr = $this->context[BacktraceContextProvider::class] ?? []) {
+            $this->dumpDebugBacktrace($dumper, $cursor);
+        }
     }
 
     /**
@@ -425,5 +431,15 @@ class Data implements \ArrayAccess, \Countable, \IteratorAggregate, \Stringable
         $stub->value = $stub->cut + ($stub->position ? \count($this->data[$stub->position]) : 0);
 
         return $stub;
+    }
+
+    private function dumpDebugBacktrace(DumperInterface $dumper, Cursor $cursor): void
+    {
+        $backtrace = $cursor->attr['backtrace'];
+
+        $dumper->dumpScalar($cursor, 'default', '');
+        $dumper->dumpScalar($cursor, 'default', '**DEBUG BACKTRACE**');
+
+        $backtrace->dump($dumper);
     }
 }

--- a/src/Symfony/Component/VarDumper/Dumper/ContextProvider/BacktraceContextProvider.php
+++ b/src/Symfony/Component/VarDumper/Dumper/ContextProvider/BacktraceContextProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Dumper\ContextProvider;
+
+use Symfony\Component\VarDumper\Caster\TraceStub;
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\VarDumperOptions;
+
+/**
+ * Provides the debug stacktrace of the VarDumper call.
+ *
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
+ */
+final class BacktraceContextProvider implements ContextProviderInterface
+{
+    private const BACKTRACE_CONTEXT_PROVIDER_DEPTH = 4;
+
+    public function __construct(
+        private readonly bool|int $limit,
+        private ?ClonerInterface $cloner
+    ) {
+        $this->cloner ??= new VarCloner();
+    }
+
+    public function getContext(): ?array
+    {
+        if (false === $this->limit) {
+            return [];
+        }
+
+        $context = [];
+        $traces = debug_backtrace(\DEBUG_BACKTRACE_IGNORE_ARGS);
+
+        for ($i = self::BACKTRACE_CONTEXT_PROVIDER_DEPTH; $i < \count($traces); ++$i) {
+            $context[] = $traces[$i];
+
+            if ($this->limit === \count($context)) {
+                break;
+            }
+        }
+
+        $stub = new TraceStub($context);
+
+        return ['backtrace' => $this->cloner->cloneVar($stub->value)];
+    }
+}

--- a/src/Symfony/Component/VarDumper/Resources/functions/dump.php
+++ b/src/Symfony/Component/VarDumper/Resources/functions/dump.php
@@ -16,21 +16,35 @@ if (!function_exists('dump')) {
     /**
      * @author Nicolas Grekas <p@tchwork.com>
      * @author Alexandre Daubois <alex.daubois@gmail.com>
+     *
+     * @template T
+     *
+     * @param T ...$vars
+     *
+     * @return T
      */
     function dump(mixed ...$vars): mixed
     {
-        if (!$vars) {
-            VarDumper::dump(new ScalarStub('🐛'));
-
-            return null;
-        }
+        $options = array_filter(
+            $vars,
+            static fn (mixed $key): bool => \in_array($key, VarDumper::AVAILABLE_OPTIONS, true),
+            \ARRAY_FILTER_USE_KEY
+        );
 
         if (array_key_exists(0, $vars) && 1 === count($vars)) {
-            VarDumper::dump($vars[0]);
+            VarDumper::dump($vars[0], null, $options);
             $k = 0;
         } else {
+            $vars = array_filter($vars, static fn (int|string $key) => !str_starts_with($key, '_'), \ARRAY_FILTER_USE_KEY);
+
+            if (!$vars) {
+                VarDumper::dump(new ScalarStub('🐛'), null, $options);
+
+                return null;
+            }
+
             foreach ($vars as $k => $v) {
-                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+                VarDumper::dump($v, is_int($k) ? 1 + $k : $k, $options);
             }
         }
 
@@ -55,11 +69,21 @@ if (!function_exists('dd')) {
             exit(1);
         }
 
+        $options = array_filter(
+            $vars,
+            static fn (mixed $key): bool => \in_array($key, VarDumper::AVAILABLE_OPTIONS, true),
+            \ARRAY_FILTER_USE_KEY
+        );
+
         if (array_key_exists(0, $vars) && 1 === count($vars)) {
-            VarDumper::dump($vars[0]);
+            VarDumper::dump($vars[0], null, $options);
         } else {
             foreach ($vars as $k => $v) {
-                VarDumper::dump($v, is_int($k) ? 1 + $k : $k);
+                if (str_starts_with($k, '_')) {
+                    continue;
+                }
+
+                VarDumper::dump($v, is_int($k) ? 1 + $k : $k, $options);
             }
         }
 

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/ContextProvider/BacktraceContextProviderTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/ContextProvider/BacktraceContextProviderTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\VarDumper\Tests\Dumper\ContextProvider;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\VarDumper\Cloner\VarCloner;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\BacktraceContextProvider;
+
+class BacktraceContextProviderTest extends TestCase
+{
+    public function testFalseBacktraceLimit()
+    {
+        $provider = new BacktraceContextProvider(false, new VarCloner());
+        $this->assertArrayNotHasKey('backtrace', $provider->getContext());
+    }
+
+    public function testPositiveBacktraceLimit()
+    {
+        $provider = new BacktraceContextProvider(2, new VarCloner());
+        $this->assertCount(2, $provider->getContext()['backtrace']);
+    }
+}

--- a/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
+++ b/src/Symfony/Component/VarDumper/Tests/Dumper/FunctionsTest.php
@@ -85,6 +85,20 @@ class FunctionsTest extends TestCase
         $this->assertSame([$var1, 'second' => $var2, 'third' => $var3], $return);
     }
 
+    public function testDumpReturnsAllNamedArgsExceptSpecialOptionOnes()
+    {
+        $this->setupVarDumper();
+
+        $var1 = 'a';
+        $var2 = 'b';
+
+        ob_start();
+        $return = dump($var1, named: $var2, _trace: true, _flags: 0);
+        ob_end_clean();
+
+        $this->assertSame([$var1, 'named' => $var2], $return);
+    }
+
     protected function setupVarDumper()
     {
         $cloner = new VarCloner();

--- a/src/Symfony/Component/VarDumper/VarDumper.php
+++ b/src/Symfony/Component/VarDumper/VarDumper.php
@@ -15,8 +15,11 @@ use Symfony\Component\ErrorHandler\ErrorRenderer\FileLinkFormatter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\VarDumper\Caster\ReflectionCaster;
+use Symfony\Component\VarDumper\Cloner\ClonerInterface;
+use Symfony\Component\VarDumper\Cloner\Data;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\ContextProvider\BacktraceContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\CliContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\RequestContextProvider;
 use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
@@ -29,18 +32,57 @@ require_once __DIR__.'/Resources/functions/dump.php';
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
+ * @author Alexandre Daubois <alex.daubois@gmail.com>
  */
 class VarDumper
 {
+    private const OPTIONS_ENVIRONMENT_KEY = 'VAR_DUMPER_OPTIONS';
+
+    public const AVAILABLE_OPTIONS = [
+        '_format',
+        '_trace',
+        '_max_items',
+        '_min_depth',
+        '_max_string',
+        '_max_depth',
+        '_max_items_per_depth',
+        '_theme',
+        '_flags',
+        '_charset',
+    ];
+
     /**
      * @var callable|null
      */
     private static $handler;
 
-    public static function dump(mixed $var, ?string $label = null): mixed
+    private static ?string $prevOptionsHash = null;
+
+    private static bool $manualHandlerRegister = false;
+
+    /**
+     * @param array{
+     *     '_format'?: ?string,
+     *     '_trace'?: bool|int|null,
+     *     '_max_items'?: ?int,
+     *     '_min_depth'?: ?int,
+     *     '_max_string'?: ?int,
+     *     '_max_depth'?: ?int,
+     *     '_max_items_per_depth'?: ?int,
+     *     '_theme'?: ?string,
+     *     '_flags'?: ?int,
+     *     '_charset'?: ?string,
+     * } $options The options to configure the dump output
+     */
+    public static function dump(mixed $var, ?string $label = null/*, array $options = [] */): mixed
     {
-        if (null === self::$handler) {
-            self::register();
+        $options = 3 <= \func_num_args() ? func_get_arg(2) : [];
+
+        parse_str($_SERVER[self::OPTIONS_ENVIRONMENT_KEY] ?? '', $envOptions);
+        $options = array_replace(array_fill_keys(self::AVAILABLE_OPTIONS, null), array_merge($options, $envOptions));
+
+        if (self::requiresRegister($options)) {
+            self::register($options);
         }
 
         return (self::$handler)($var, $label);
@@ -56,49 +98,62 @@ class VarDumper
         }
 
         self::$handler = $callable;
+        self::$manualHandlerRegister = true;
 
         return $prevHandler;
     }
 
-    private static function register(): void
+    private static function register(array $options): void
     {
-        $cloner = new VarCloner();
+        self::$prevOptionsHash = self::getOptionsHash($options);
+
+        $cloner = self::createVarClonerFactoryWithOptions($options);
         $cloner->addCasters(ReflectionCaster::UNSET_CLOSURE_FILE_INFO);
 
-        $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? null;
+        $format = $_SERVER['VAR_DUMPER_FORMAT'] ?? $options['_format'];
+        $charset = $options['_charset'];
+        $flags = $options['_flags'] ?? 0;
+
         switch (true) {
             case 'html' === $format:
-                $dumper = new HtmlDumper();
+                $dumper = new HtmlDumper(null, $charset, $flags);
+                $dumper->setTheme($options['_theme'] ?? 'dark');
                 break;
             case 'cli' === $format:
-                $dumper = new CliDumper();
+                $dumper = new CliDumper(null, $charset, $flags);
                 break;
             case 'server' === $format:
             case $format && 'tcp' === parse_url($format, \PHP_URL_SCHEME):
                 $host = 'server' === $format ? $_SERVER['VAR_DUMPER_SERVER'] ?? '127.0.0.1:9912' : $format;
-                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? new CliDumper() : new HtmlDumper();
-                $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders());
+                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ?
+                    new CliDumper(null, $charset, $flags) : new HtmlDumper(null, $charset, $flags);
+                $dumper = new ServerDumper($host, $dumper, self::getDefaultContextProviders($cloner));
                 break;
             default:
-                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ? new CliDumper() : new HtmlDumper();
+                $dumper = \in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true) ?
+                    new CliDumper(null, $charset, $flags) : new HtmlDumper(null, $charset, $flags);
         }
 
         if (!$dumper instanceof ServerDumper) {
-            $dumper = new ContextualizedDumper($dumper, [new SourceContextProvider()]);
+            $dumper = new ContextualizedDumper($dumper, [
+                new SourceContextProvider(),
+                new BacktraceContextProvider($options['_trace'] ?? false, $cloner),
+            ]);
         }
 
-        self::$handler = function ($var, ?string $label = null) use ($cloner, $dumper) {
-            $var = $cloner->cloneVar($var);
+        self::$handler = function ($var, ?string $label = null) use ($cloner, $dumper, $options) {
+            $var = self::cloneVarWithOptions($cloner, $var, $options);
 
             if (null !== $label) {
                 $var = $var->withContext(['label' => $label]);
             }
 
+            $var = $var->withContext(array_merge($var->getContext(), ['options' => $options]));
             $dumper->dump($var);
         };
     }
 
-    private static function getDefaultContextProviders(): array
+    private static function getDefaultContextProviders(ClonerInterface $cloner): array
     {
         $contextProviders = [];
 
@@ -113,6 +168,51 @@ class VarDumper
         return $contextProviders + [
             'cli' => new CliContextProvider(),
             'source' => new SourceContextProvider(null, null, $fileLinkFormatter),
+            'backtrace' => new BacktraceContextProvider(false, $cloner),
         ];
+    }
+
+    private static function cloneVarWithOptions(ClonerInterface $cloner, mixed $var, array $options): Data
+    {
+        $var = $cloner->cloneVar($var);
+
+        if (null !== $maxDepth = $options['_max_depth']) {
+            $var = $var->withMaxDepth($maxDepth);
+        }
+
+        if (null !== $maxItemsPerDepth = $options['_max_items_per_depth']) {
+            $var = $var->withMaxItemsPerDepth($maxItemsPerDepth);
+        }
+
+        return $var;
+    }
+
+    private static function requiresRegister(array $options): bool
+    {
+        return null === self::$handler || (self::getOptionsHash($options) !== self::$prevOptionsHash && !self::$manualHandlerRegister);
+    }
+
+    private static function getOptionsHash(array $options): string
+    {
+        return md5(serialize($options));
+    }
+
+    private static function createVarClonerFactoryWithOptions(array $options): ClonerInterface
+    {
+        $cloner = new VarCloner();
+
+        if (null !== $maxItems = $options['_max_items']) {
+            $cloner->setMaxItems($maxItems);
+        }
+
+        if (null !== $minDepth = $options['_min_depth']) {
+            $cloner->setMinDepth($minDepth);
+        }
+
+        if (null !== $maxString = $options['_max_string']) {
+            $cloner->setMaxString($maxString);
+        }
+
+        return $cloner;
     }
 }


### PR DESCRIPTION
… at runtime

| Q             | A
| ------------- | ---
| Branch?       | 7.2 for features / 5.4, 6.4, and 7.1 for bug fixes <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please update src/**/CHANGELOG.md files -->
| Deprecations? | yes/no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead -->
| License       | MIT

<!--
Replace this notice by a description of your feature/bugfix.
This will help reviewers and should be a good start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the latest branch.
 - For new features, provide some code snippets to help understand usage.
 - Changelog entry should follow https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
 - Never break backward compatibility (see https://symfony.com/bc).
-->
