### PR TITLE
[HttpClient] Add support for the `max_connect_duration` option

### DIFF
--- a/src/Symfony/Component/HttpClient/AmpHttpClient.php
+++ b/src/Symfony/Component/HttpClient/AmpHttpClient.php
@@ -128,7 +128,12 @@ final class AmpHttpClient implements HttpClientInterface, LoggerAwareInterface, 
             $request->addHeader($h[0], $h[1]);
         }
 
-        $request->setTcpConnectTimeout($options['timeout']);
+        if (0 < $options['max_connect_duration']) {
+            $request->setTcpConnectTimeout($options['max_connect_duration']);
+        } else {
+            $request->setTcpConnectTimeout($options['timeout']);
+        }
+
         $request->setTlsHandshakeTimeout($options['timeout']);
         $request->setTransferTimeout($options['max_duration']);
         $request->setInactivityTimeout(0);

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+8.1
+---
+
+ * Add support for the `max_connect_duration` option
+
 8.0
 ---
 

--- a/src/Symfony/Component/HttpClient/CurlHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CurlHttpClient.php
@@ -285,6 +285,10 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             $curlopts[\CURLOPT_TIMEOUT_MS] = 1000 * $options['max_duration'];
         }
 
+        if (0 < $options['max_connect_duration']) {
+            $curlopts[\CURLOPT_CONNECTTIMEOUT_MS] = (int) (1000 * $options['max_connect_duration']);
+        }
+
         if (!empty($options['extra']['curl']) && \is_array($options['extra']['curl'])) {
             $this->validateExtraCurlOptions($options['extra']['curl']);
             $curlopts += $options['extra']['curl'];
@@ -468,6 +472,8 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             \CURLOPT_INTERFACE => 'bindto',
             \CURLOPT_TIMEOUT_MS => 'max_duration',
             \CURLOPT_TIMEOUT => 'max_duration',
+            \CURLOPT_CONNECTTIMEOUT_MS => 'max_connect_duration',
+            \CURLOPT_CONNECTTIMEOUT => 'max_connect_duration',
             \CURLOPT_MAXREDIRS => 'max_redirects',
             \CURLOPT_POSTREDIR => 'max_redirects',
             \CURLOPT_PROXY => 'proxy',
@@ -506,8 +512,6 @@ final class CurlHttpClient implements HttpClientInterface, LoggerAwareInterface,
             \CURLOPT_URL,
             \CURLOPT_FOLLOWLOCATION,
             \CURLOPT_HEADER,
-            \CURLOPT_CONNECTTIMEOUT,
-            \CURLOPT_CONNECTTIMEOUT_MS,
             \CURLOPT_HTTP_VERSION,
             \CURLOPT_PORT,
             \CURLOPT_DNS_USE_GLOBAL_CACHE,

--- a/src/Symfony/Component/HttpClient/HttpClientTrait.php
+++ b/src/Symfony/Component/HttpClient/HttpClientTrait.php
@@ -186,6 +186,7 @@ trait HttpClientTrait
         }
 
         $options['max_duration'] = isset($options['max_duration']) ? (float) $options['max_duration'] : 0;
+        $options['max_connect_duration'] = isset($options['max_connect_duration']) ? (float) $options['max_connect_duration'] : 0;
         $options['headers'] = array_merge(...array_values($options['normalized_headers']));
 
         return [$url, $options];

--- a/src/Symfony/Component/HttpClient/HttpOptions.php
+++ b/src/Symfony/Component/HttpClient/HttpOptions.php
@@ -230,6 +230,16 @@ class HttpOptions
     /**
      * @return $this
      */
+    public function setMaxConnectDuration(float $maxConnectDuration): static
+    {
+        $this->options['max_connect_duration'] = $maxConnectDuration;
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
     public function bindTo(string $bindto): static
     {
         $this->options['bindto'] = $bindto;

--- a/src/Symfony/Component/HttpClient/NativeHttpClient.php
+++ b/src/Symfony/Component/HttpClient/NativeHttpClient.php
@@ -198,6 +198,10 @@ final class NativeHttpClient implements HttpClientInterface, LoggerAwareInterfac
             $options['headers'][] = 'User-Agent: Symfony HttpClient (Native)';
         }
 
+        if (0 < $options['max_connect_duration']) {
+            $options['timeout'] = min($options['max_connect_duration'], $options['timeout']);
+        }
+
         if (0 < $options['max_duration']) {
             $options['timeout'] = min($options['max_duration'], $options['timeout']);
         }

--- a/src/Symfony/Component/HttpClient/Response/AmpResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/AmpResponse.php
@@ -87,6 +87,7 @@ final class AmpResponse implements ResponseInterface, StreamableInterface
         $info['download_content_length'] = -1.0;
         $info['user_data'] = $options['user_data'];
         $info['max_duration'] = $options['max_duration'];
+        $info['max_connect_duration'] = $options['max_connect_duration'];
         $info['debug'] = '';
 
         $onProgress = $options['on_progress'] ?? static function () {};

--- a/src/Symfony/Component/HttpClient/Response/CurlResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/CurlResponse.php
@@ -71,6 +71,7 @@ final class CurlResponse implements ResponseInterface, StreamableInterface
         $this->info['http_method'] = $method;
         $this->info['user_data'] = $options['user_data'] ?? null;
         $this->info['max_duration'] = $options['max_duration'] ?? null;
+        $this->info['max_connect_duration'] = $options['max_connect_duration'] ?? null;
         $this->info['start_time'] ??= microtime(true);
         $this->info['original_url'] = $originalUrl ?? $this->info['url'] ?? curl_getinfo($ch, \CURLINFO_EFFECTIVE_URL);
         $info = &$this->info;

--- a/src/Symfony/Component/HttpClient/Response/MockResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/MockResponse.php
@@ -146,6 +146,7 @@ class MockResponse implements ResponseInterface, StreamableInterface
         $response->info['http_code'] = 0;
         $response->info['user_data'] = $options['user_data'] ?? null;
         $response->info['max_duration'] = $options['max_duration'] ?? null;
+        $response->info['max_connect_duration'] = $options['max_connect_duration'] ?? null;
         $response->info['url'] = $url;
         $response->info['original_url'] = $url;
 
@@ -282,6 +283,7 @@ class MockResponse implements ResponseInterface, StreamableInterface
             'start_time' => $response->info['start_time'],
             'user_data' => $response->info['user_data'],
             'max_duration' => $response->info['max_duration'],
+            'max_connect_duration' => $response->info['max_connect_duration'],
             'http_code' => $response->info['http_code'],
         ] + $info + $response->info;
 

--- a/src/Symfony/Component/HttpClient/Response/NativeResponse.php
+++ b/src/Symfony/Component/HttpClient/Response/NativeResponse.php
@@ -70,6 +70,7 @@ final class NativeResponse implements ResponseInterface, StreamableInterface
         $info['original_url'] = implode('', $info['url']);
         $info['user_data'] = $options['user_data'];
         $info['max_duration'] = $options['max_duration'];
+        $info['max_connect_duration'] = $options['max_connect_duration'];
         ++$multi->responseCount;
 
         $this->initializer = static fn (self $response) => null === $response->remaining;

--- a/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CurlHttpClientTest.php
@@ -138,6 +138,21 @@ class CurlHttpClientTest extends HttpClientTestCase
         ]);
     }
 
+    public function testOverridingMaxConnectDurationUsingCurlOptions()
+    {
+        $httpClient = $this->getHttpClient(__FUNCTION__);
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot set "CURLOPT_CONNECTTIMEOUT_MS" with "extra.curl", use option "max_connect_duration" instead.');
+
+        $httpClient->request('GET', 'http://localhost:8057/', [
+            'extra' => [
+                'curl' => [
+                    \CURLOPT_CONNECTTIMEOUT_MS => 5000,
+                ],
+            ],
+        ]);
+    }
+
     public function testKeepAuthorizationHeaderOnRedirectToSameHostWithConfiguredHostToIpAddressMapping()
     {
         $httpClient = $this->getHttpClient(__FUNCTION__);

--- a/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/HttpOptionsTest.php
@@ -49,4 +49,9 @@ class HttpOptionsTest extends TestCase
         $options->setHeader('Accept', 'application/html');
         $this->assertSame(['Accept' => 'application/html', 'Accept-Language' => 'en-US,en;q=0.5'], $options->toArray()['headers']);
     }
+
+    public function testSetMaxConnectDuration()
+    {
+        $this->assertSame(5.0, (new HttpOptions())->setMaxConnectDuration(5.0)->toArray()['max_connect_duration']);
+    }
 }

--- a/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/MockHttpClientTest.php
@@ -483,6 +483,10 @@ class MockHttpClientTest extends HttpClientTestCase
                     ['error' => 'Max duration was reached.']
                 );
                 break;
+
+            case 'testMaxConnectDurationInfo':
+                $responses[] = new MockResponse('');
+                break;
         }
 
         return new MockHttpClient($responses);

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.4",
         "psr/log": "^1|^2|^3",
-        "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+        "symfony/http-client-contracts": "~3.4.5|^3.5.3",
         "symfony/service-contracts": "^2.5|^3"
     },
     "require-dev": {

--- a/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
+++ b/src/Symfony/Contracts/HttpClient/HttpClientInterface.php
@@ -55,6 +55,8 @@ interface HttpClientInterface
         'timeout' => null,      // float - the idle timeout (in seconds) - defaults to ini_get('default_socket_timeout')
         'max_duration' => 0,    // float - the maximum execution time (in seconds) for the request+response as a whole;
                                 //   a value lower than or equal to 0 means it is unlimited
+        'max_connect_duration' => 0,    // float - the maximum duration (in seconds) allowed for DNS + TCP + TLS connection;
+                                        //   a value lower than or equal to 0 means it is unlimited
         'bindto' => '0',        // string - the interface or the local socket to bind to
         'verify_peer' => true,  // see https://php.net/context.ssl for the following options
         'verify_host' => true,

--- a/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
+++ b/src/Symfony/Contracts/HttpClient/Test/HttpClientTestCase.php
@@ -1156,6 +1156,17 @@ abstract class HttpClientTestCase extends TestCase
         $this->assertLessThan(10, $duration);
     }
 
+    public function testMaxConnectDurationInfo()
+    {
+        $client = $this->getHttpClient(__FUNCTION__);
+        $response = $client->request('GET', 'http://localhost:8057/', [
+            'max_connect_duration' => 10.0,
+        ]);
+
+        $this->assertSame(10.0, $response->getInfo('max_connect_duration'));
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
     public function testWithOptions()
     {
         $client = $this->getHttpClient(__FUNCTION__);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 7.4 for features / 6.4, 7.2, or 7.3 for bug fixes
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- if yes, also update src/**/CHANGELOG.md -->
| Deprecations? | yes/no <!-- if yes, also update UPGRADE-*.md and src/**/CHANGELOG.md -->
| Issues        | Fix #... <!-- prefix each issue number with "Fix #"; no need to create an issue if none exists, explain below -->
| License       | MIT

<!--
🛠️ Replace this text with a concise explanation of your change:
- What it does and why it's needed
- A simple example of how it works (include PHP, YAML, etc.)
- If it modifies existing behavior, include a before/after comparison

Contributor guidelines:
- ✅ Add tests and ensure they pass
- 🐞 Bug fixes must target the **lowest maintained** branch where they apply
  https://symfony.com/releases#maintained-symfony-branches
- ✨ New features and deprecations must target the **feature** branch
  and must add an entry to the changelog file of the patched component:
  https://symfony.com/doc/current/contributing/code/conventions.html#writing-a-changelog-entry
- 🔒 Do not break backward compatibility:
  https://symfony.com/bc
-->
